### PR TITLE
Cascade example

### DIFF
--- a/src/components/3-ClassComposition/ClassComposition.css
+++ b/src/components/3-ClassComposition/ClassComposition.css
@@ -1,0 +1,11 @@
+.custom {
+  border-color: purple;
+}
+
+.customTwo {
+  border-color: yellow !important;
+}
+
+.customThree {
+  composes: borderGreen from './utils.css';
+}

--- a/src/components/3-ClassComposition/ClassComposition.js
+++ b/src/components/3-ClassComposition/ClassComposition.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 
+import styles from './ClassComposition.css';
 import StyleVariantA from './StyleVariantA/StyleVariantA';
 import StyleVariantB from './StyleVariantB/StyleVariantB';
 
@@ -8,7 +9,7 @@ export default class ClassComposition extends Component {
   render() {
     return (
       <div>
-        <StyleVariantA />
+        <StyleVariantA className={`${styles.custom} ${styles.customTwo} ${styles.customThree}`} />
         <br />
         <StyleVariantB />
       </div>

--- a/src/components/3-ClassComposition/StyleVariantA/StyleVariantA.js
+++ b/src/components/3-ClassComposition/StyleVariantA/StyleVariantA.js
@@ -6,7 +6,7 @@ export default class StyleVariantA extends Component {
 
   render() {
     return (
-      <div className={styles.root}>
+      <div className={`${styles.root} ${this.props.className}`}>
         <p className={styles.text}>Style Variant A</p>
       </div>
     );

--- a/src/components/3-ClassComposition/utils.css
+++ b/src/components/3-ClassComposition/utils.css
@@ -1,0 +1,3 @@
+.borderGreen {
+  border-color: green;
+}


### PR DESCRIPTION
When composing classes, the resulting cascade is not obvious and it's not always possible to get the desired results.

In this instance, I render a component that internally composes some other styles, but I also attempt to pass through additional styling from a consumer (`.custom`) 

The latter is ignored, due to the resulting cascade.
